### PR TITLE
foundry.toml: Add optimizer setting

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -16,6 +16,10 @@ extra_output = ["storageLayout"]
 # forces recompilation, required by Upgradable contracts
 force = true
 
+optimizer = true
+optimizer_runs = 200
+via_ir = true
+
 # testing does not care about the upgrade checks above
 # so we disable them with 
 [profile.test]
@@ -37,5 +41,14 @@ runs = 100
 # invariant options
 [invariant]
 runs = 20
+
+[profile.ci]
+optimizer = true
+optimizer_runs = 200
+via_ir = true
+ffi = false
+ast = false
+build_info = false
+force = false
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,7 +18,6 @@ force = true
 
 optimizer = true
 optimizer_runs = 200
-via_ir = true
 
 # testing does not care about the upgrade checks above
 # so we disable them with 


### PR DESCRIPTION
Without optimizer setting for CI workflow on GitHub, default values are used, which caused a contract to exceed codesizelimit, rendering the CI process failed at `forge build`. Added optimizer setting for [profile.ci] inside foundry.toml

Local:
<img width="809" alt="Screenshot 2025-01-20 at 20 48 38" src="https://github.com/user-attachments/assets/5256d3f5-8561-45c5-8b3d-d27c3f43c193" />

Github env:
<img width="819" alt="Screenshot 2025-01-20 at 20 49 16" src="https://github.com/user-attachments/assets/5f9498d7-0d60-4f8b-8086-498878139dd8" />


